### PR TITLE
fix: 修复行内公式导致换行

### DIFF
--- a/src/libs/formats/notion/convert-to-md.ts
+++ b/src/libs/formats/notion/convert-to-md.ts
@@ -275,8 +275,7 @@ function fixEquations(body: HTMLElement) {
 		annotation.textContent = annotation.textContent.trim();
 		// 如果已经是行级公式，则跳过处理
 		if (/\\begin\{.*?\}[\s\S]+\\end\{.*?\}/gmi.test(annotation.textContent)) continue;
-		// 单行公式强制改为行级公式
-		annotation.textContent = `\\begin{align}\n${annotation.textContent}\n\\end{align}`
+        
 		mathEl.replaceWith(annotation)
 	}
 }


### PR DESCRIPTION
行内公式不应该转行级公式，因为当公式和段落文字混排时，转换后会将一段文字拆成很多行，导致排版混乱。