### PR TITLE
fix: 修正普通折叠块转换不正常

### DIFF
--- a/src/libs/formats/notion/convert-to-md.ts
+++ b/src/libs/formats/notion/convert-to-md.ts
@@ -79,6 +79,7 @@ export async function readToMarkdown(info: NotionResolverInfo, file: ZipEntryFil
 	replaceElementsWithChildren(body, 'div.indented');
 	replaceElementsWithChildren(body, 'details');
 	fixToggleHeadings(body);
+	fixNormalToggle(body);
 	fixNotionLists(body, 'ul');
 	fixNotionLists(body, 'ol');
 
@@ -420,6 +421,22 @@ function fixToggleHeadings(body: HTMLElement) {
 				break;
 			}
 		}
+	}
+}
+
+/// 普通折叠块的处理和标题折叠块差不多, 需要替换为li, 但Notion导出时会在上一级有空的li, 也需要进行删除
+function fixNormalToggle(body: HTMLElement) {
+	const toggleHeadings = HTMLElementfindAll(body, 'summary');
+	for (const heading of toggleHeadings) {
+		let style = heading.getAttribute('style');
+		if (style) continue;
+
+		const parentLi = heading.closest('li');
+		if (parentLi) {
+			// 删除上一级的空li
+			parentLi.replaceWith(...parentLi.childNodes);
+		}
+		heading.replaceWith(createEl("li", { text: heading.textContent ?? '' }));
 	}
 }
 


### PR DESCRIPTION
我在使用插件时遇到普通折叠块转换不正常的情况, 我尝试修正了这个问题.

具体表现为带有折叠块的标题丢失, 少了对应的层级, 可以用以下Notion导入的文档进行测试.

[列表测试-fb585d0e-ffca-43c6-9b16-c833e8f01b3c_Export-2a304303-8bcd-4ab9-8c44-b65a44156fa7.zip](https://github.com/user-attachments/files/18958168/-fb585d0e-ffca-43c6-9b16-c833e8f01b3c_Export-2a304303-8bcd-4ab9-8c44-b65a44156fa7.zip)
